### PR TITLE
fix(add/rm): migrate topic mutations to updateTopics

### DIFF
--- a/source/commands/add.sh
+++ b/source/commands/add.sh
@@ -8,6 +8,7 @@ __PROGRAM__=$(basename $0)
 __COMMAND_NAME__=${__PROGRAM__%%.*}
 __GH_EXTENSION_DIR__="$(dirname "$0")/../../"
 __COMMANDS_DIR__="$(dirname "$0")"
+__CORE_DIR__="${__GH_EXTENSION_DIR__}/source/core"
 
 #
 # IMPORTS
@@ -15,6 +16,7 @@ __COMMANDS_DIR__="$(dirname "$0")"
 
 source "${__GH_EXTENSION_DIR__}/source/extras/addons.sh"
 source "${__COMMANDS_DIR__}/${__COMMAND_NAME__}.help"
+source "${__CORE_DIR__}/topic.sh"
 
 #
 # VARS
@@ -33,8 +35,11 @@ main() {
     reponame \
     query \
     mutation \
-    default_loop_separator \
+    data \
     repo_id \
+    repo_topics \
+    new_topics \
+    merged_topics \
     repo_full_name
 
   x:log "__COMMAND_NAME__[$__COMMAND_NAME__] __GH_EXTENSION_DIR__[$__GH_EXTENSION_DIR__] __COMMANDS_DIR__[$__COMMANDS_DIR__]"
@@ -56,18 +61,36 @@ main() {
   x:log "reponame: ${reponame}"
 
   query='
-    query repositoryIdFor($reponame: String!, $owner: String!) {
+    query repositoryIdWithTopicsFor($reponame: String!, $owner: String!) {
       repository(name: $reponame, owner: $owner) {
         id
+        topics: repositoryTopics(first: 100) {
+          edges {
+            node {
+              topic {
+                name
+              }
+            }
+          }
+        }
       }
     }
   '
 
+  local template='{{ .data.repository.id }}:{{ range $idx, $element := .data.repository.topics.edges }}{{ if $idx }} {{end}}{{ $element.node.topic.name }}{{ end }}'
+
   mutation='
-    mutation addTopicToRepoWithIdOwnedBy($repoId: String!, $topic: String!) {
-      acceptTopicSuggestion(input: {repositoryId: $repoId,  name: $topic}) {
-        topic {
-          name
+    mutation updateTopicsForRepo($repoId: ID!, $names: [String!]!) {
+      updateTopics(input: {repositoryId: $repoId, topicNames: $names}) {
+        invalidTopicNames
+        repository {
+          repositoryTopics(first: 100) {
+            nodes {
+              topic {
+                name
+              }
+            }
+          }
         }
       }
     }
@@ -75,34 +98,33 @@ main() {
 
   repo_full_name="${owner}/${reponame}"
 
-  x:log "Getting repo id using a graphql query..."
-  repo_id=$(gh api graphql -F owner="${owner}" -F reponame="${reponame}" \
+  x:log "Getting repo id and current topics using a graphql query..."
+  data=$(gh api graphql -F owner="${owner}" -F reponame="${reponame}" \
     -f query="${query}" \
-    -q '.data.repository.id' 2>/dev/null)
+    -t "$template" 2>/dev/null)
   x:check $? "Repository[${repo_full_name}] not found. Unable to get its repository ID"
-  x:log "repo_id: ${repo_id}"
 
-  x:log "Adding topics[${topics}] to repo[${repo_full_name}..."
+  repo_id="$(echo "$data" | cut -d\: -f 1)"
+  repo_topics="$(echo "$data" | cut -d\: -f 2)"
+  x:log "repo_id: ${repo_id} repo_topics: ${repo_topics}"
 
-  default_loop_separator=$IFS
-  IFS=","
-  for rawtopic in $topics; do
+  x:log "Parsing requested topics[${topics}]..."
+  new_topics=$(topic:parse "$topics")
+  x:log "new_topics: ${new_topics}"
 
-    x:log "Trimming rawtopic[${rawtopic}]..."
+  merged_topics=$(topic:union "${repo_topics}" "${new_topics}")
+  x:log "merged_topics: ${merged_topics}"
 
-    topic=$(echo $rawtopic | sed -e 's/^[[:space:]]*//')
-    x:check $?
-    x:log "topic[${topic}] trimmed."
-
-    x:log "Adding topic[${topic}] to repo[${repo_full_name}] of id[${repo_id}] using a graphql mutation..."
-    gh api graphql -F repoId="${repo_id}" -F topic="${topic}" \
-      -f query="${mutation}" \
-      --silent 2>/dev/null
-    x:check $? "Fail to add topic[${topic}] to the repository[${repo_full_name}]"
-    x:log "Topic[${topic}] added."
-
+  local -a name_args=()
+  for topic in $merged_topics; do
+    name_args+=(-F "names[]=${topic}")
   done
-  IFS=${default_loop_separator}
+
+  x:log "Adding topics[${new_topics}] to repo[${repo_full_name}] of id[${repo_id}] using a graphql mutation..."
+  gh api graphql "${name_args[@]}" -F repoId="${repo_id}" \
+    -f query="${mutation}" \
+    --silent 2>/dev/null
+  x:check $? "Fail to add topics[${new_topics}] to the repository[${repo_full_name}]"
 
   x:success "Topics[$topics] added to repo[${repo_full_name}]"
 

--- a/source/commands/rm.sh
+++ b/source/commands/rm.sh
@@ -39,9 +39,10 @@ main() {
     data
 
   local repo_id \
-    repo_topics
+    repo_topics \
+    remove_topics \
+    remaining_topics
 
-  local default_loop_separator
   local repo_full_name
 
   x:log "__COMMAND_NAME__[$__COMMAND_NAME__] __GH_EXTENSION_DIR__[$__GH_EXTENSION_DIR__] __COMMANDS_DIR__[$__COMMANDS_DIR__]"
@@ -82,10 +83,17 @@ main() {
   local template='{{ .data.repository.id }}:{{ range $idx, $element := .data.repository.topics.edges }}{{ if $idx }} {{end}}{{ $element.node.topic.name }}{{ end }}'
 
   mutation='
-    mutation removeTopicToRepoWithIdOwnedBy($repoId: String!, $topic: String!) {
-      declineTopicSuggestion(input: { repositoryId: $repoId, name: $topic, reason: NOT_RELEVANT }) {
-        topic {
-          name
+    mutation updateTopicsForRepo($repoId: ID!, $names: [String!]!) {
+      updateTopics(input: {repositoryId: $repoId, topicNames: $names}) {
+        invalidTopicNames
+        repository {
+          repositoryTopics(first: 100) {
+            nodes {
+              topic {
+                name
+              }
+            }
+          }
         }
       }
     }
@@ -93,46 +101,41 @@ main() {
 
   repo_full_name="${owner}/${reponame}"
 
-  x:log "Getting repo id using a graphql query..."
+  x:log "Getting repo id and current topics using a graphql query..."
   data=$(gh api graphql -F owner="${owner}" -F reponame="${reponame}" \
     -f query="${query}" \
     -t "$template" 2>/dev/null)
   x:check $? "Repository[${repo_full_name}] not found. Unable to get its repository ID"
 
-  repo_id="$(echo $data | cut -d\: -f 1)"
-  repo_topics="$(echo $data | cut -d\: -f 2)"
-  x:log "repo_id: ${repo_id}\
-  repo_topics: ${repo_topics}"
+  repo_id="$(echo "$data" | cut -d\: -f 1)"
+  repo_topics="$(echo "$data" | cut -d\: -f 2)"
+  x:log "repo_id: ${repo_id} repo_topics: ${repo_topics}"
 
-  x:log "Checking if the given topics[${topics}] are part of repository topics..."
-  for rawtopic in $topics; do
+  x:log "Parsing requested topics[${topics}]..."
+  remove_topics=$(topic:parse "$topics")
+  x:log "remove_topics: ${remove_topics}"
 
-    x:log "Trimming rawtopic[${rawtopic}]..."
-    topic="$(echo $rawtopic | sed -e 's/^[[:space:]]*//')"
-
+  x:log "Checking if the given topics[${remove_topics}] are part of repository topics..."
+  for topic in $remove_topics; do
     if ! topic:contains "$topic" "${repo_topics}"; then
       x:err "Topic[$topic] not found on repository[${repo_full_name}]  — topics[${repo_topics}]"
     fi
-
   done
 
-  x:log "Removing topics[${topics}] to repo[${repo_full_name}..."
+  remaining_topics=$(topic:difference "${repo_topics}" "${remove_topics}")
+  x:log "remaining_topics: ${remaining_topics}"
 
-  for rawtopic in $topics; do
-
-    x:log "Trimming rawtopic[${rawtopic}]..."
-    topic=$(echo $rawtopic | sed -e 's/^[[:space:]]*//')
-    x:check $?
-    x:log "topic[${topic}] trimmed."
-
-    x:log "Removing topic[${topic}] to repo[${repo_full_name}] of id[${repo_id}] using a graphql mutation..."
-    gh api graphql -F repoId="${repo_id}" -F topic="${topic}" \
-      -f query="${mutation}" \
-      --silent 2>/dev/null
-    x:check $? "Fail to remove topic[${topic}] to the repository[${repo_full_name}]"
-    x:log "Topic[${topic}] removed."
-
+  local -a name_args=()
+  for topic in $remaining_topics; do
+    name_args+=(-F "names[]=${topic}")
   done
+  [[ ${#name_args[@]} -eq 0 ]] && name_args=(-F "names[]")
+
+  x:log "Removing topics[${remove_topics}] from repo[${repo_full_name}] of id[${repo_id}] using a graphql mutation..."
+  gh api graphql "${name_args[@]}" -F repoId="${repo_id}" \
+    -f query="${mutation}" \
+    --silent 2>/dev/null
+  x:check $? "Fail to remove topics[${remove_topics}] from the repository[${repo_full_name}]"
 
   x:success "Topics[$topics] removed to repo[${repo_full_name}]"
 
@@ -190,6 +193,4 @@ done
 # EXEC
 #
 
-space_separated_topics="${arg_topics//,/ }"
-
-main "${arg_reponame}" "$space_separated_topics"
+main "${arg_reponame}" "$arg_topics"

--- a/source/core/topic.sh
+++ b/source/core/topic.sh
@@ -15,3 +15,67 @@ topic:contains() {
   fi
 
 }
+
+# topic:parse: splits a comma-separated topic list, trims whitespace and dedupes
+# params
+#   - raw comma-separated topic names (eg: "foo, bar,bar")
+# stdout: space-separated, deduped topic list (eg: "foo bar")
+topic:parse() {
+  local raw="$1"
+  local default_loop_separator=$IFS
+  local rawtopic
+  local topic
+  local parsed=""
+
+  IFS=","
+  for rawtopic in $raw; do
+    topic=$(echo "$rawtopic" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    [[ -z "$topic" ]] && continue
+    if ! topic:contains "$topic" "$parsed"; then
+      parsed="${parsed:+$parsed }${topic}"
+    fi
+  done
+  IFS=$default_loop_separator
+
+  echo "$parsed"
+}
+
+# topic:union: merges two space-separated topic lists, deduped
+# params
+#   - base space-separated topic list
+#   - additional space-separated topic list
+# stdout: space-separated, deduped union of both lists
+topic:union() {
+  local base="$1"
+  local additional="$2"
+  local result="$base"
+  local topic
+
+  for topic in $additional; do
+    if ! topic:contains "$topic" "$result"; then
+      result="${result:+$result }${topic}"
+    fi
+  done
+
+  echo "$result"
+}
+
+# topic:difference: removes topics found in the second list from the first
+# params
+#   - base space-separated topic list
+#   - space-separated topic list to remove
+# stdout: space-separated topic list with removals applied
+topic:difference() {
+  local base="$1"
+  local remove="$2"
+  local result=""
+  local topic
+
+  for topic in $base; do
+    if ! topic:contains "$topic" "$remove"; then
+      result="${result:+$result }${topic}"
+    fi
+  done
+
+  echo "$result"
+}


### PR DESCRIPTION
## Summary
- `add.sh`/`rm.sh` used `acceptTopicSuggestion`/`declineTopicSuggestion`, which GitHub removed from the GraphQL API alongside the deprecated suggested-topics feature — causing every `gh topic add`/`gh topic rm` invocation to fail.
- Both commands now query the repository's id + current topics, compute the desired topic set (union for `add`, difference for `rm`), and submit a single `updateTopics` mutation instead of one mutation per topic.
- Added `topic:parse`, `topic:union`, and `topic:difference` to `source/core/topic.sh` to share the trim/dedupe/merge logic between `add.sh` and `rm.sh` (both already relied on `topic:contains` from this file).
- `rm.sh` validates that every requested topic currently exists on the repo before mutating, preserving prior UX behavior.
- Owner/repo resolution (`owner/repo` vs bare `repo` inferred from `gh api user`) is unchanged.

## Test plan
- [x] `bash -n` on `add.sh`, `rm.sh`, `topic.sh` — all pass
- [x] Local dry-run of `topic:parse`/`topic:union`/`topic:difference`/`topic:contains` with whitespace, duplicate, and empty inputs — confirmed correct output
- [x] Verified empty-array GraphQL variable construction (`-F 'names[]'`) for the case where `rm` removes all remaining topics
- [x] Live `gh topic add`/`gh topic rm` against a real repository (not run — would mutate a real repo's topics)